### PR TITLE
Add SimpleJWT Authentication to Tasks API

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 import os
 from pathlib import Path
+from datetime import timedelta
 from django.core.management.utils import get_random_secret_key
 from dotenv import load_dotenv
 
@@ -43,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework_simplejwt.token_blacklist',
     'corsheaders',
     'tasks',
 ]
@@ -131,3 +133,20 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Authentication and Authorization
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ]
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True
+}

--- a/backend/tasks/permissions.py
+++ b/backend/tasks/permissions.py
@@ -1,0 +1,14 @@
+"""
+Custom Permissions for Tasks app.
+"""
+from rest_framework.permissions import BasePermission
+
+
+class IsOwner(BasePermission):
+    """
+    Custom permission to only allow owners of an object to read, update or delete it.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return obj.user == request.user
+    

--- a/backend/tasks/serializers.py
+++ b/backend/tasks/serializers.py
@@ -48,37 +48,9 @@ class RegisterSerializer(serializers.ModelSerializer):
         extra_kwargs = {"password": {"write_only": True}}
 
     def create(self, validated_data):
-        user = User.objects.create_user(validated_data["username"], None, validated_data["password"])
+        user = User.objects.create_user(
+            username=validated_data["username"],
+            password=validated_data["password"]
+        )
         return user
     
-
-class LoginSerializer(serializers.Serializer):
-    """
-    Login serializer class.
-    """
-    username = serializers.CharField()
-    password = serializers.CharField()
-
-    def validate(self, attrs):
-        """
-        Validate the username and password.
-        Returns the validated user, or raises a ValidationError.
-        """
-        user = authenticate(**attrs)
-        if user and user.is_active:
-            return user
-        raise serializers.ValidationError("Invalid credentials.")
-    
-    def create(self, validated_data):
-        """
-        This method is not needed for authentication, but it must be implemented
-        to satisfy the abstract method requirements. 
-        """
-        raise NotImplementedError("Create method is not implemented for LoginSerializer")
-
-    def update(self, instance, validated_data):
-        """
-        This method is not needed for authentication, but it must be implemented
-        to satisfy the abstract method requirements.
-        """
-        raise NotImplementedError("Update method is not implemented for LoginSerializer")

--- a/backend/tasks/serializers.py
+++ b/backend/tasks/serializers.py
@@ -1,6 +1,8 @@
 """
 Tasks app serializers.
 """
+from django.contrib.auth.models import User
+from django.contrib.auth import authenticate
 from rest_framework import serializers
 from .models import Task
 
@@ -16,3 +18,67 @@ class TaskSerializer(serializers.ModelSerializer):
         """
         model = Task
         fields = "__all__"
+        read_only_fields = ("id", "user")
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """
+    User serializer class for returning and updating user details in the API.
+    """
+
+    class Meta:
+        """
+        Serializer Meta class.
+        """
+        model = User
+        fields = ("id", "username")
+
+
+class RegisterSerializer(serializers.ModelSerializer):
+    """
+    Register serializer class.
+    """
+
+    class Meta:
+        """
+        Serializer Meta class.
+        """
+        model = User
+        fields = ("username", "password")
+        extra_kwargs = {"password": {"write_only": True}}
+
+    def create(self, validated_data):
+        user = User.objects.create_user(validated_data["username"], None, validated_data["password"])
+        return user
+    
+
+class LoginSerializer(serializers.Serializer):
+    """
+    Login serializer class.
+    """
+    username = serializers.CharField()
+    password = serializers.CharField()
+
+    def validate(self, attrs):
+        """
+        Validate the username and password.
+        Returns the validated user, or raises a ValidationError.
+        """
+        user = authenticate(**attrs)
+        if user and user.is_active:
+            return user
+        raise serializers.ValidationError("Invalid credentials.")
+    
+    def create(self, validated_data):
+        """
+        This method is not needed for authentication, but it must be implemented
+        to satisfy the abstract method requirements. 
+        """
+        raise NotImplementedError("Create method is not implemented for LoginSerializer")
+
+    def update(self, instance, validated_data):
+        """
+        This method is not needed for authentication, but it must be implemented
+        to satisfy the abstract method requirements.
+        """
+        raise NotImplementedError("Update method is not implemented for LoginSerializer")

--- a/backend/tasks/tests.py
+++ b/backend/tasks/tests.py
@@ -1,3 +1,118 @@
-from django.test import TestCase
+from rest_framework.test import APITestCase, APIClient
+from django.urls import reverse
+from rest_framework import status
+from django.contrib.auth.models import User
+from .models import Task
+from rest_framework_simplejwt.tokens import RefreshToken
 
-# Create your tests here.
+class UserAuthTests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.register_url = reverse('auth_register')
+        self.login_url = reverse('token_obtain_pair')
+        self.refresh_url = reverse('token_refresh')
+        self.logout_url = reverse('auth_logout')
+        self.user_data = {
+            'username': 'testuser',
+            'password': 'password123'
+        }
+
+    def test_user_registration(self):
+        response = self.client.post(self.register_url, self.user_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_user_login(self):
+        User.objects.create_user(**self.user_data)
+        response = self.client.post(self.login_url, self.user_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
+
+    def test_token_refresh(self):
+        User.objects.create_user(**self.user_data)
+        login_response = self.client.post(self.login_url, self.user_data)
+        refresh_token = login_response.data['refresh']
+        response = self.client.post(self.refresh_url, {'refresh': refresh_token})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+
+    def test_logout(self):
+        User.objects.create_user(**self.user_data)
+        login_response = self.client.post(self.login_url, self.user_data)
+        token = login_response.data['access']
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
+        refresh_token = login_response.data['refresh']
+        response = self.client.post(self.logout_url, {'refresh': refresh_token})
+        self.assertEqual(response.status_code, status.HTTP_205_RESET_CONTENT)
+
+
+class TaskTests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.register_url = reverse('auth_register')
+        self.login_url = reverse('token_obtain_pair')
+        self.user_data = {
+            'username': 'testuser',
+            'password': 'password123'
+        }
+        self.user = User.objects.create_user(**self.user_data)
+        self.login_response = self.client.post(self.login_url, self.user_data)
+        self.access_token = self.login_response.data['access']
+        self.tasks_url = reverse('task-list')
+        self.task_data = {
+            'title': 'Test Task',
+            'description': 'Test Description'
+        }
+
+    def test_create_task(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access_token}')
+        response = self.client.post(self.tasks_url, self.task_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['title'], self.task_data['title'])
+
+    def test_get_tasks(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access_token}')
+        self.client.post(self.tasks_url, self.task_data)
+        response = self.client.get(self.tasks_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_get_specific_task(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access_token}')
+        create_response = self.client.post(self.tasks_url, self.task_data)
+        task_id = create_response.data['id']
+        response = self.client.get(reverse('task-detail', args=[task_id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], self.task_data['title'])
+
+    def test_update_task(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access_token}')
+        create_response = self.client.post(self.tasks_url, self.task_data)
+        task_id = create_response.data['id']
+        updated_data = {'title': 'Updated Task', 'description': 'Updated Description'}
+        response = self.client.put(reverse('task-detail', args=[task_id]), updated_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], updated_data['title'])
+
+    def test_delete_task(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access_token}')
+        create_response = self.client.post(self.tasks_url, self.task_data)
+        task_id = create_response.data['id']
+        response = self.client.delete(reverse('task-detail', args=[task_id]))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_unauthorized_task_access(self):
+        task_id = 10000
+        response = self.client.get(reverse('task-detail', args=[task_id]))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_forbidden_task_access(self):
+        another_user = User.objects.create_user(username='anotheruser', password='password123')
+        another_user_token = RefreshToken.for_user(another_user).access_token
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {another_user_token}')
+        create_response = self.client.post(self.tasks_url, self.task_data)
+        task_id = create_response.data['id']
+
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access_token}')
+        response = self.client.get(reverse('task-detail', args=[task_id]))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/tasks/urls.py
+++ b/backend/tasks/urls.py
@@ -1,9 +1,13 @@
 """
-URL configuration for tasks app.
+URL endpoint configuration for tasks app.
 """
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import TaskViewSet
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
+from .views import (TaskViewSet, LogoutView)
 
 
 router = DefaultRouter()
@@ -11,4 +15,7 @@ router.register('tasks', TaskViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('auth/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('auth/logout/', LogoutView.as_view(), name='auth_logout'),
 ]

--- a/backend/tasks/urls.py
+++ b/backend/tasks/urls.py
@@ -7,7 +7,7 @@ from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
 )
-from .views import (TaskViewSet, LogoutView)
+from .views import (TaskViewSet, RegisterView, LogoutView)
 
 
 router = DefaultRouter()
@@ -15,6 +15,7 @@ router.register('tasks', TaskViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('auth/register/', RegisterView.as_view(), name='auth_register'),
     path('auth/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('auth/logout/', LogoutView.as_view(), name='auth_logout'),

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -1,7 +1,12 @@
 """
 Tasks app views.
 """
-from rest_framework import viewsets
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import viewsets, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework_simplejwt.tokens import RefreshToken
+from .permissions import IsOwner
 from .models import Task
 from .serializers import TaskSerializer
 
@@ -18,3 +23,48 @@ class TaskViewSet(viewsets.ModelViewSet):
     """
     queryset = Task.objects.all()
     serializer_class = TaskSerializer
+    
+    def get_permissions(self):
+        """
+        Set the permission classes based on the action.
+
+        If the action is 'create', the permission class is IsAuthenticated.
+        Otherwise, the permission class is IsAuthenticated and IsOwner.
+        """
+        if self.action == 'create':
+            permission_classes = [IsAuthenticated]
+        else:
+            permission_classes = [IsAuthenticated, IsOwner]
+        return [permission() for permission in permission_classes]
+    
+    def perform_create(self, serializer):
+        """
+        Set the user field of the task to the authenticated user.
+        """
+        serializer.save(user=self.request.user)
+
+    def get_queryset(self):
+        """
+        Filter tasks by the authenticated user.
+        """
+        return self.queryset.filter(user=self.request.user)
+    
+
+class LogoutView(APIView):
+    """
+    View for logging out the user.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        """
+        Log out the user and blacklist their refresh token.
+        """
+        try:
+            refresh_token = request.data["refresh"]
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+
+            return Response(status=status.HTTP_205_RESET_CONTENT)
+        except Exception as e:
+            return Response(data=str(e) ,status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This PR integrates SimpleJWT authentication into the Tasks API to enhance security and streamline the authentication process. With this implementation, users can register, log in, refresh tokens, and log out while securing their endpoints with JWT Tokens.

**Usage:**
- **Register: `POST /auth/register/`**
- **Login: `POST /auth/token/`**
- **Refresh Token: `POST /auth/token/refresh/`**
- **Logout: `POST /auth/logout/`**