### PR TITLE
Dockerize the project

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,13 @@
+# Python-related
+__pycache__/
+.pytest_cache/
+*.pyc
+*.pyo
+*.pyd
+.DS_Store
+
+# Virtual environment
+venv/
+
+# Local development
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+# backend/Dockerfile
+FROM python:3.12
+
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+
+RUN pip install --upgrade pip
+
+RUN pip install -r requirements.txt
+
+COPY . /app

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,8 @@ asgiref==3.8.1
 Django==5.0.7
 django-cors-headers==4.4.0
 djangorestframework==3.15.2
+djangorestframework-simplejwt==5.3.1
+PyJWT==2.8.0
 python-dotenv==1.0.1
 sqlparse==0.5.1
 tzdata==2024.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  backend:
+    build: ./backend
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+    environment:
+      - DJANGO_SECRET_KEY=${SECRET_KEY:-default_secret_key}
+      - DEBUG=True
+  frontend:
+    build: ./frontend
+    command: npm start
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "3000:3000"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,11 @@
+# Node.js-related
+node_modules
+npm-debug.log
+yarn-error.log
+
+# OS-generated
+.DS_Store
+Thumbs.db
+
+# Local development
+.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+# frontend/Dockerfile
+FROM node:20.16.0
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . /app/
+
+RUN npm run build


### PR DESCRIPTION
This PR adds necessary configurations for dockerizing the project for ease of sharing. Now running the project is as easy as `cloning` and running `docker-compose up --build` provided one has `Docker` and `Docker Compose` installed and running.