### PR TITLE
Update frontend docker settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DEBUG=True
   frontend:
     build: ./frontend
-    command: npm start
+    command: npm run start
     volumes:
       - ./frontend:/app
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,11 @@
 # frontend/Dockerfile
-FROM node:20
+FROM node:20.16.0
 
 WORKDIR /app
 
 COPY package*.json ./
+
+RUN npm install -g npm@latest
 
 RUN npm install
 


### PR DESCRIPTION
 This PR fixes an issue faced by other parties when running the project with Docker. `npm install` and subsequently `npm start` were failing. The solution is updating npm `npm install -g npm@latest` before running `npm install` and using `npm run start` in place of `npm start`.